### PR TITLE
Fix #363 'Link with editor' button doesn't work with Rascal Navigator

### DIFF
--- a/rascal-eclipse/plugin.xml
+++ b/rascal-eclipse/plugin.xml
@@ -792,6 +792,9 @@
              <contentExtension
                    pattern="org.eclipse.ui.navigator.resourceContent">
              </contentExtension>
+             <contentExtension
+                   pattern="org.eclipse.ui.navigator.resources.linkHelper">
+             </contentExtension>
           </includes>
        </viewerContentBinding>
        <viewerActionBinding


### PR DESCRIPTION
Using the ResourceLinkHelper (org.eclipse.ui.navigator.resources.linkHelper) as LinkHelper for the Rascal Navigator seems to fix this.

https://github.com/usethesource/rascal/issues/363
